### PR TITLE
Update action to run on Node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,5 +9,5 @@ inputs:
     default: "4.4"
 
 runs:
-  using: node12
+  using: node16
   main: dist/index.js


### PR DESCRIPTION
Node 12 will be [deprecated](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) soon

Addresses part of remotion-dev/remotion#1400